### PR TITLE
feat: Add admin and owner tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ export default handler;
 - `m`: The full message object from `node-telegram-bot-api`.
 - `text`: A string containing the arguments passed to the command.
 
+## 👑 Owner Commands
+
+These commands can only be used by the bot owner defined in `config.js`.
+
+| Command | Description |
+|---------|-------------|
+| `/restart` | Restarts the bot process. |
+| `/broadcast <text>` | Sends a message to all chats the bot is in. |
+
+## 👮 Admin Commands
+
+These commands can be used by group administrators. Most commands require you to reply to a user's message.
+
+| Command | Description |
+|---------|-------------|
+| `/ban` or `/kick` | Bans a user from the group. |
+| `/mute` | Mutes a user, preventing them from sending messages. |
+| `/unmute` | Unmutes a previously muted user. |
+| `/promote` | Promotes a user to a group admin. |
+| `/demote` | Demotes an admin back to a regular user. |
+| `/pin` | Pins the message you replied to. |
+| `/del` | Deletes the message you replied to. |
+
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to fork the repository, make changes, and open a pull request.

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ console.log(chalk.magenta.italic('                                    👨‍�
 const bot = new TelegramBot(config.telegramBotToken, { polling: true })
 const plugins = new Map()
 const pluginsDir = path.join(process.cwd(), 'plugins')
+global.chatIds = new Set()
 
 async function loadPlugins() {
   plugins.clear()
@@ -77,6 +78,7 @@ bot.on('message', async (msg) => {
   const from = msg.from
   const chat = msg.chat
   const text = msg.text || ''
+  if (chat) global.chatIds.add(chat.id)
   const userTag = from.username ? `@${from.username}` : from.first_name
   const chatType = chat.type === 'private' ? 'PRIVATE' : 'GROUP'
   const chatName = chat.type === 'group' ? chat.title : 'Direct Message'

--- a/plugins/ban.js
+++ b/plugins/ban.js
@@ -1,0 +1,73 @@
+import { isOwner, isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  // 1. Check if it's a group chat
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  // 2. Check if the command is a reply
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan pengguna yang ingin Anda ban.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderId = m.from.id;
+  const targetId = m.reply_to_message.from.id;
+  const targetUsername = m.reply_to_message.from.first_name;
+
+  // 3. Check if sender is an admin
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, senderId);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  // 4. Check if bot is an admin and has ban permissions
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_restrict_members) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk memblokir anggota di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  // 5. Prevent banning the owner or another admin
+  if (isOwner(targetId)) {
+    return conn.sendMessage(chatId, 'Tidak bisa memblokir Owner Bot.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+  const targetIsAdmin = await isGroupAdmin(conn, chatId, targetId);
+  if (targetIsAdmin) {
+    return conn.sendMessage(chatId, 'Tidak bisa memblokir sesama admin.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+
+  // 6. Ban the user
+  try {
+    await conn.banChatMember(chatId, targetId);
+    conn.sendMessage(chatId, `✅ Pengguna ${targetUsername} telah berhasil diblokir dari grup.`, {
+      reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Ban error:', err);
+    conn.sendMessage(chatId, `Gagal memblokir pengguna. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['ban', 'kick'];
+handler.help = ['ban/kick (reply to user)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/broadcast.js
+++ b/plugins/broadcast.js
@@ -1,0 +1,56 @@
+import { isOwner } from '../utils.js';
+
+// Simple delay function
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+const handler = async ({ conn, m, text }) => {
+  if (!isOwner(m.from.id)) {
+    return conn.sendMessage(m.chat.id, 'Perintah ini hanya untuk Owner.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const broadcastMessage = text.trim();
+  if (!broadcastMessage) {
+    return conn.sendMessage(m.chat.id, 'Silakan masukkan pesan untuk di-broadcast.\nContoh: /broadcast Halo semua!', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const chatIds = Array.from(global.chatIds || []);
+  if (chatIds.length === 0) {
+    return conn.sendMessage(m.chat.id, 'Tidak ada chat yang terdaftar untuk broadcast.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  await conn.sendMessage(m.chat.id, `📢 Memulai broadcast ke ${chatIds.length} chat...`, {
+    reply_to_message_id: m.message_id
+  });
+
+  let successCount = 0;
+  let failureCount = 0;
+
+  for (const chatId of chatIds) {
+    try {
+      await conn.sendMessage(chatId, broadcastMessage);
+      successCount++;
+      await delay(300); // 300ms delay to avoid rate limiting
+    } catch (err) {
+      console.error(`Gagal mengirim broadcast ke chat ${chatId}:`, err.message);
+      failureCount++;
+    }
+  }
+
+  const reportMessage = `✅ Broadcast selesai.\n\nBerhasil terkirim: ${successCount}\nGagal terkirim: ${failureCount}`;
+  await conn.sendMessage(m.chat.id, reportMessage, {
+    reply_to_message_id: m.message_id
+  });
+};
+
+handler.command = ['broadcast', 'bc'];
+handler.help = ['broadcast <pesan>'];
+handler.tags = ['owner'];
+handler.private = true;
+
+export default handler;

--- a/plugins/delete.js
+++ b/plugins/delete.js
@@ -1,0 +1,53 @@
+import { isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    // Silently ignore in private chats
+    return;
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan yang ingin Anda hapus.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, m.from.id);
+  if (!senderIsAdmin) {
+    // To avoid clutter, don't send a message if a non-admin tries to use it.
+    // Just delete their /del command.
+    try {
+        await conn.deleteMessage(chatId, m.message_id);
+    } catch (e) {
+        console.error("Couldn't delete non-admin's /del command:", e.message);
+    }
+    return;
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_delete_messages) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk menghapus pesan di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    // Delete the target message
+    await conn.deleteMessage(chatId, m.reply_to_message.message_id);
+    // Delete the command message
+    await conn.deleteMessage(chatId, m.message_id);
+  } catch (err) {
+    console.error('Delete error:', err);
+    // It might fail if the message is old, so don't send a failure message to the group.
+  }
+};
+
+handler.command = ['del', 'delete'];
+handler.help = ['del (reply to message)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/demote.js
+++ b/plugins/demote.js
@@ -1,0 +1,68 @@
+import { isOwner, isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan admin yang ingin Anda turunkan jabatannya.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderId = m.from.id;
+  const targetId = m.reply_to_message.from.id;
+  const targetUsername = m.reply_to_message.from.first_name;
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, senderId);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_promote_members) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk mengubah jabatan anggota di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (isOwner(targetId)) {
+    return conn.sendMessage(chatId, 'Tidak bisa menurunkan jabatan Owner Bot.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    await conn.promoteChatMember(chatId, targetId, {
+      can_change_info: false,
+      can_delete_messages: false,
+      can_invite_users: false,
+      can_restrict_members: false,
+      can_pin_messages: false,
+      can_promote_members: false,
+    });
+    conn.sendMessage(chatId, `✅ Jabatan admin untuk pengguna ${targetUsername} telah dicabut.`, {
+      reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Demote error:', err);
+    conn.sendMessage(chatId, `Gagal menurunkan jabatan pengguna. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['demote'];
+handler.help = ['demote (reply to user)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -2,7 +2,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import moment from 'moment-timezone'
-import config from '../config.js'
+import { isOwner } from '../utils.js';
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -14,8 +14,8 @@ const MAX_MESSAGE_LENGTH = 3500
 let handler = async ({ conn, m }) => {
   const name = m.from?.first_name || 'Pengguna'
   const userId = m.from?.id
-  const isOwner = config.owner.includes(userId)
-  const role = isOwner ? 'Owner' : 'User'
+  const userIsOwner = isOwner(userId)
+  const role = userIsOwner ? 'Owner' : 'User'
   const waktu = moment().tz('Asia/Jakarta').format('dddd, DD MMMM YYYY HH:mm:ss')
   
   const args = m.text?.split(' ') || []

--- a/plugins/mute.js
+++ b/plugins/mute.js
@@ -1,0 +1,77 @@
+import { isOwner, isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan pengguna yang ingin Anda bisukan (mute).', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderId = m.from.id;
+  const targetId = m.reply_to_message.from.id;
+  const targetUsername = m.reply_to_message.from.first_name;
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, senderId);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_restrict_members) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk membisukan anggota di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (isOwner(targetId)) {
+    return conn.sendMessage(chatId, 'Tidak bisa membisukan Owner Bot.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+  const targetIsAdmin = await isGroupAdmin(conn, chatId, targetId);
+  if (targetIsAdmin) {
+    return conn.sendMessage(chatId, 'Tidak bisa membisukan sesama admin.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    // Restrict the user from sending messages.
+    await conn.restrictChatMember(chatId, targetId, {
+      can_send_messages: false,
+      can_send_media_messages: false,
+      can_send_other_messages: false,
+      can_add_web_page_previews: false,
+    });
+
+    // Also, create an unmute command.
+    const unmuteCommand = `/unmute`;
+
+    conn.sendMessage(chatId, `✅ Pengguna ${targetUsername} telah dibisukan. Mereka tidak bisa mengirim pesan sampai di-unmute.`, {
+      reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Mute error:', err);
+    conn.sendMessage(chatId, `Gagal membisukan pengguna. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['mute'];
+handler.help = ['mute (reply to user)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/pin.js
+++ b/plugins/pin.js
@@ -1,0 +1,55 @@
+import { isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan yang ingin Anda sematkan (pin).', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, m.from.id);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_pin_messages) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk menyematkan pesan di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    await conn.pinChatMessage(chatId, m.reply_to_message.message_id, {
+      disable_notification: false,
+    });
+    // Telegram automatically sends a "message pinned" notification, so a custom one isn't strictly needed.
+    // We can send a confirmation reply if we want.
+    await conn.sendMessage(chatId, '✅ Pesan telah disematkan.', {
+        reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Pin error:', err);
+    conn.sendMessage(chatId, `Gagal menyematkan pesan. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['pin'];
+handler.help = ['pin (reply to message)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/promote.js
+++ b/plugins/promote.js
@@ -1,0 +1,68 @@
+import { isOwner, isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan pengguna yang ingin Anda promosikan menjadi admin.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderId = m.from.id;
+  const targetId = m.reply_to_message.from.id;
+  const targetUsername = m.reply_to_message.from.first_name;
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, senderId);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_promote_members) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk mempromosikan anggota di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (isOwner(targetId)) {
+    return conn.sendMessage(chatId, 'Owner Bot tidak perlu dipromosikan.', {
+        reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    await conn.promoteChatMember(chatId, targetId, {
+      can_change_info: false,
+      can_delete_messages: true,
+      can_invite_users: true,
+      can_restrict_members: true,
+      can_pin_messages: true,
+      can_promote_members: false, // Important: prevent new admins from promoting others
+    });
+    conn.sendMessage(chatId, `✅ Pengguna ${targetUsername} telah berhasil dipromosikan menjadi admin.`, {
+      reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Promote error:', err);
+    conn.sendMessage(chatId, `Gagal mempromosikan pengguna. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['promote'];
+handler.help = ['promote (reply to user)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;

--- a/plugins/restart.js
+++ b/plugins/restart.js
@@ -1,0 +1,26 @@
+import { isOwner } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  if (!isOwner(m.from.id)) {
+    return conn.sendMessage(m.chat.id, 'Perintah ini hanya untuk Owner.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    await conn.sendMessage(m.chat.id, 'Bot akan di-restart...', {
+      reply_to_message_id: m.message_id
+    });
+    process.exit(0);
+  } catch (err) {
+    console.error('Restart error:', err);
+    conn.sendMessage(m.chat.id, 'Gagal me-restart bot.');
+  }
+};
+
+handler.command = ['restart'];
+handler.help = ['restart'];
+handler.tags = ['owner'];
+handler.private = true;
+
+export default handler;

--- a/plugins/unmute.js
+++ b/plugins/unmute.js
@@ -1,0 +1,62 @@
+import { isOwner, isGroupAdmin, botIsAdmin } from '../utils.js';
+
+const handler = async ({ conn, m }) => {
+  const chatId = m.chat.id;
+
+  if (m.chat.type !== 'group' && m.chat.type !== 'supergroup') {
+    return conn.sendMessage(chatId, 'Perintah ini hanya bisa digunakan di dalam grup.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  if (!m.reply_to_message) {
+    return conn.sendMessage(chatId, 'Balas pesan pengguna yang ingin Anda aktifkan kembali (unmute).', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const senderId = m.from.id;
+  const targetId = m.reply_to_message.from.id;
+  const targetUsername = m.reply_to_message.from.first_name;
+
+  const senderIsAdmin = await isGroupAdmin(conn, chatId, senderId);
+  if (!senderIsAdmin) {
+    return conn.sendMessage(chatId, 'Hanya admin yang bisa menggunakan perintah ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  const botAdminData = await botIsAdmin(conn, chatId);
+  if (!botAdminData || !botAdminData.can_restrict_members) {
+    return conn.sendMessage(chatId, 'Saya tidak memiliki izin untuk mengubah izin anggota di grup ini.', {
+      reply_to_message_id: m.message_id
+    });
+  }
+
+  try {
+    // Restore default permissions for the user.
+    await conn.restrictChatMember(chatId, targetId, {
+      can_send_messages: true,
+      can_send_media_messages: true,
+      can_send_other_messages: true,
+      can_add_web_page_previews: true,
+    });
+
+    conn.sendMessage(chatId, `✅ Pengguna ${targetUsername} telah di-unmute. Mereka sekarang bisa mengirim pesan lagi.`, {
+      reply_to_message_id: m.message_id
+    });
+  } catch (err) {
+    console.error('Unmute error:', err);
+    conn.sendMessage(chatId, `Gagal meng-unmute pengguna. Error: ${err.message}`, {
+      reply_to_message_id: m.message_id
+    });
+  }
+};
+
+handler.command = ['unmute'];
+handler.help = ['unmute (reply to user)'];
+handler.tags = ['admin'];
+handler.group = true;
+handler.private = false;
+
+export default handler;


### PR DESCRIPTION
This commit introduces a comprehensive set of moderation and management tools for group administrators and the bot owner.

New Owner Commands:
- /restart: Restarts the bot process.
- /broadcast: Sends a message to all chats the bot is in.

New Admin Commands:
- /ban, /kick: Bans a user from the group.
- /mute, /unmute: Mutes/unmutes a user in the group.
- /promote, /demote: Promotes/demotes a user to/from admin.
- /pin: Pins a message in the group.
- /del: Deletes a message.

This is implemented by:
- Creating a new plugin file for each command.
- Adding helper functions in `utils.js` to check for admin/owner permissions and bot permissions, ensuring robust and secure command handling.
- Updating `index.js` to collect chat IDs for the broadcast feature.
- Updating `plugins/menu.js` and `README.md` to reflect the new features.